### PR TITLE
New kindly-file template spec attribute "configs" and validations

### DIFF
--- a/kindly/cmd/apply.py
+++ b/kindly/cmd/apply.py
@@ -38,16 +38,29 @@ def apply(ctx):
         o.set_context()
         spinner.succeed()
 
-    with halo.Halo(
-        text=f"Loading image '{s.image}'", spinner='dots', enabled=c.spinner
-    ) as spinner:
-        d.load_image()
-        spinner.succeed()
+    if s.template_spec_contains('image'):
+        with halo.Halo(
+            text=f"Loading image '{s.image}'",
+            spinner='dots',
+            enabled=c.spinner,
+        ) as spinner:
+            d.load_image()
+            spinner.succeed()
 
-    with halo.Halo(
-        text=f"Upgrade package '{s.packager_chart}'",
-        spinner='dots',
-        enabled=c.spinner,
-    ) as spinner:
-        p.upgrade()
-        spinner.succeed()
+    if s.template_spec_contains('packager'):
+        with halo.Halo(
+            text=f"Upgrade package '{s.packager_chart}'",
+            spinner='dots',
+            enabled=c.spinner,
+        ) as spinner:
+            p.upgrade()
+            spinner.succeed()
+
+    if s.template_spec_contains('configs'):
+        with halo.Halo(
+            text=f"Apply updated configs in '{s.configs_path}'",
+            spinner='dots',
+            enabled=c.spinner,
+        ) as spinner:
+            o.update_objects()
+            spinner.succeed()

--- a/kindly/cmd/create.py
+++ b/kindly/cmd/create.py
@@ -36,24 +36,37 @@ def create(ctx):
         d.create()
         spinner.succeed()
 
-    with halo.Halo(
-        text=f"Loading image '{s.image}'", spinner='dots', enabled=c.spinner
-    ) as spinner:
-        d.load_image()
-        spinner.succeed()
+    if s.template_spec_contains('image'):
+        with halo.Halo(
+            text=f"Loading image '{s.image}'",
+            spinner='dots',
+            enabled=c.spinner,
+        ) as spinner:
+            d.load_image()
+            spinner.succeed()
 
-    with halo.Halo(
-        text=f"Create package namespace '{s.packager_namespace}'",
-        spinner='dots',
-        enabled=c.spinner,
-    ) as spinner:
-        o.create_namespace()
-        spinner.succeed()
+    if s.template_spec_contains('packager'):
+        with halo.Halo(
+            text=f"Create package namespace '{s.packager_namespace}'",
+            spinner='dots',
+            enabled=c.spinner,
+        ) as spinner:
+            o.create_namespace()
+            spinner.succeed()
 
-    with halo.Halo(
-        text=f"Install package '{s.packager_chart}'",
-        spinner='dots',
-        enabled=c.spinner,
-    ) as spinner:
-        p.install()
-        spinner.succeed()
+        with halo.Halo(
+            text=f"Install package '{s.packager_chart}'",
+            spinner='dots',
+            enabled=c.spinner,
+        ) as spinner:
+            p.install()
+            spinner.succeed()
+
+    if s.template_spec_contains('configs'):
+        with halo.Halo(
+            text=f"Create objects from yaml definitions in '{s.configs_path}'",
+            spinner='dots',
+            enabled=c.spinner,
+        ) as spinner:
+            o.create_objects()
+            spinner.succeed()

--- a/kindly/orchestrator.py
+++ b/kindly/orchestrator.py
@@ -64,3 +64,38 @@ class Kubectl(object):
             debug=self._config.debug,
             env=self._config.env,
         )
+
+    def create_objects(self):
+        '''Create objects defined in the path on Kind cluster. '''
+
+        commands = [
+            'kubectl',
+            'create',
+            '--save-config',
+            '-f',
+            self._deployment_spec.configs_path,
+        ]
+
+        util.run(
+            commands,
+            stream=False,
+            debug=self._config.debug,
+            env=self._config.env,
+        )
+
+    def update_objects(self):
+        '''Apply changes to objects defined in the path on Kind cluster. '''
+
+        commands = [
+            'kubectl',
+            'apply',
+            '-f',
+            self._deployment_spec.configs_path,
+        ]
+
+        util.run(
+            commands,
+            stream=False,
+            debug=self._config.debug,
+            env=self._config.env,
+        )

--- a/test/resources/configs/deployment.yaml
+++ b/test/resources/configs/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kindlydeploy
+  name: kindlydeploy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kindlydeploy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: kindlydeploy
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        resources: {}
+status: {}

--- a/test/resources/configs/service.yaml
+++ b/test/resources/configs/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kindlydeploy
+  name: kindlydeploysvc
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: kindlydeploy
+  type: NodePort
+status:
+  loadBalancer: {}

--- a/test/resources/kindly.yml
+++ b/test/resources/kindly.yml
@@ -7,10 +7,12 @@ spec:
   template:
     spec:
       image:
-        repository: test/kindly
-        pullPolicy: IfNotPresent
-        tag: latest
+         repository: test/kindly
+         pullPolicy: IfNotPresent
+         tag: latest
       packager:
         name: foo
         chart: test/resources/charts/foo
         namespace: foo
+      configs:
+        configPath: test/resources/configs/

--- a/test/test_orchestrator.py
+++ b/test/test_orchestrator.py
@@ -62,3 +62,32 @@ def test_create_namespace(_instance, patched_run):
 
 def test_create_namespace_with_debug(_instance, patched_run):
     pass
+
+
+def test_create_objects(_instance, patched_run):
+    _instance.create_objects()
+
+    commands = [
+        'kubectl',
+        'create',
+        '--save-config',
+        '-f',
+        'test/resources/configs/',
+    ]
+    patched_run.assert_called_once_with(
+        commands, stream=False, debug=False, env=_instance._config.env
+    )
+
+
+def test_update_objects(_instance, patched_run):
+    _instance.update_objects()
+
+    commands = [
+        'kubectl',
+        'apply',
+        '-f',
+        'test/resources/configs/',
+    ]
+    patched_run.assert_called_once_with(
+        commands, stream=False, debug=False, env=_instance._config.env
+    )

--- a/test/test_spec.py
+++ b/test/test_spec.py
@@ -68,3 +68,9 @@ def test_packager_namespace(_instance):
     x = 'foo'
 
     assert x == _instance.packager_namespace
+
+
+def test_configs_path(_instance):
+    x = 'test/resources/configs/'
+
+    assert x == _instance.configs_path


### PR DESCRIPTION
      New Attribute: Just like image and packager ( helm ), added a configs dirpath where users can place their collection of k8s object definition files
                     users should be able to create new objects and apply new changes which essentially calls,
                      * "kubectl create -f <path> " for creating objects and
                      * "kubectl apply -f <path> " for updating objects
      Validations: Validate kindly-file if user provided all required attributes template:spec:<attrib> [ image, packager, configs ]